### PR TITLE
Fix the default application name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ hackrf/Readme.md:
 
 hackrf: hackrf/Readme.md
 
-$(APP)/main.bin:
-	$(MAKE) -C $(APP) main.bin
+$(APP)/$(APP).bin:
+	$(MAKE) -C $(APP) $(APP).bin
 	
-$(APP)/main.dfu:
-	$(MAKE) -C $(APP) main.dfu
+$(APP)/$(APP).dfu:
+	$(MAKE) -C $(APP) $(APP).dfu
 	
 $(APP).bin: $(APP)/feldtest.bin
 	cp $< $@


### PR DESCRIPTION
With a fresh checkout (commit 9bbaa117cfb2568fabac30967d2e92f2905ea68a), trying to build the firmware fails with the following error. 

```
$ make
make: *** No rule to make target 'feldtest/feldtest.dfu', needed by 'feldtest.dfu'.  Stop.
$
```
