### PR TITLE
Fix: udev rules are case sensitive

### DIFF
--- a/smartflash/90-rad1o-flash.rules
+++ b/smartflash/90-rad1o-flash.rules
@@ -4,7 +4,7 @@
 # HackRF One compability
 ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="plugdev"
 # new rad1o PID
-ATTR{idVendor}=="1d50", ATTR{idProduct}=="CC15", SYMLINK+="rad1o-%k", MODE="660", GROUP="plugdev"
+ATTR{idVendor}=="1d50", ATTR{idProduct}=="cc15", SYMLINK+="rad1o-%k", MODE="660", GROUP="plugdev"
 # NXP DFU mode
 ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="plugdev"
 # rad1o "full flash" mode


### PR DESCRIPTION
Fixed the udev rule. As far as I know they are case sensitive. At least the gentoo wiki says so. And the rule did not work until I changed the `CC` to `cc`...
