### PR TITLE
Restore cpu_speed when exiting ws2812_sendarray

### DIFF
--- a/rad1olib/light_ws2812_cortex.c
+++ b/rad1olib/light_ws2812_cortex.c
@@ -111,6 +111,6 @@ void ws2812_sendarray(uint8_t *data,int datlen)
 			);
 	}
 	/* Reset CPU speed to previous */
-	cpu_clock_set(_cpu_speed);
+	cpu_clock_set(old_cpu_speed);
 }
 


### PR DESCRIPTION
_cpu_speed was set instead of old_cpu_speed
