### PR TITLE
 added description to restore broken filesystems 

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -71,6 +71,7 @@ Prerequisite: rad1o is connected to USB
 To flash the firmware permanently, simply copy the .bin file to the mounted mass storage of rad1o.
 If you want to just run the firmware once without permanently storing it on the rad1o, you will need the `dfu-util` mentioned above and run the `make flash` command.
 
+To fix issues on some boards that are not flashable by FlashGUI or to restore the filesystem on the radio in gerneral run `sudo mkfs.msdos -I /dev/sdx` and resotre the firmware again with `FlashGUI`. 
 
 ## OS X setup:
 


### PR DESCRIPTION
To fix issues on some boards that are not flashable by FlashGUI or to restore the filesystem on the radio in gerneral run `sudo mkfs.msdos -I /dev/sdx` and resotre the firmware again with `FlashGUI`. 
