### PR TITLE
doc/build.md: Fixed doc problem with "echo"

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -16,7 +16,7 @@
 
           ```
           sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
-          echo "Package: gcc-arm-none-eabi\n Pin: release o=LP-PPA-terry.guo-gcc-arm-embedded\n Priority: 501" |sudo tee /etc/apt/preferences.d/pin-gcc-arm-embedded
+          echo -e "Package: gcc-arm-none-eabi\n Pin: release o=LP-PPA-terry.guo-gcc-arm-embedded\n Priority: 501" |sudo tee /etc/apt/preferences.d/pin-gcc-arm-embedded
           sudo apt-get update
           ```
       `sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi`


### PR DESCRIPTION
doc/build.md: Fixed problem with "echo" not interpreting backslash escapes by default.

echo -> echo -e
