### PR TITLE
Display error message if "nick.lcd" is not found.

### DIFF
--- a/l0dables/nick_image.c
+++ b/l0dables/nick_image.c
@@ -9,5 +9,19 @@
 #include "usetable.h"
 
 void ram(void){
-    lcdShowImageFile("nick.lcd");
+  if (lcdShowImageFile("nick.lcd") != 0) {
+    lcdClear();
+    lcdNl();
+    lcdPrintln("-------------------");
+    lcdPrintln("-   Image file    -");
+    lcdPrintln("-    nick.lcd     -");
+    lcdPrintln("-   not found.    -");
+    lcdPrintln("-                 -");
+    lcdPrintln("- Copy it here or -");
+    lcdPrintln("- choose another  -");
+    lcdPrintln("-    animation.   -");
+    lcdPrintln("-------------------");
+    lcdNl();
+    lcdDisplay();
+  }
 }


### PR DESCRIPTION
l0dables/nick_image.c: Check return value of image loading and display
error message if file is not found.  Note that it does not exist by
default.
