### PR TITLE
Add l0adables that show the nick and have LED interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.gen
 .deps
 flashapp/xsvf.inc
+files/nick.lcd

--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ IRC channel: irc://irc.darkfasel.net/#rad1o (Port 6697 oder 9999, TLS-only, IPv6
 [Build instructions](doc/build.md)
 
 [Some notes on toggling LEDs](doc/debugging.md)
+
+
+## instructions in how to create your own loadables and update them to the rad1o
+
+add your .c file to f1rmware/l0adables
+add the n1c and c1d to the Makefile in f1rmware/l0adables
+run make in f1rmware/l0adables
+run cp [name of your file].c1d /[location of your mounted rad1o]/
+unmount the rad1o
+restart the device
+
+If you get an error of incompatible build numbers, you propably need to recompile the whole project in the f1rmware (run make) 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,18 @@ IRC channel: irc://irc.darkfasel.net/#rad1o (Port 6697 oder 9999, TLS-only, IPv6
 ## instructions in how to create your own loadables and update them to the rad1o
 
 add your .c file to f1rmware/l0adables
+
 add the n1c and c1d to the Makefile in f1rmware/l0adables
+
 run make in f1rmware/l0adables
+
 run cp [name of your file].c1d /[location of your mounted rad1o]/
+
 unmount the rad1o
+
 restart the device
+
+
+
 
 If you get an error of incompatible build numbers, you propably need to recompile the whole project in the f1rmware (run make) 

--- a/l0dables/Makefile
+++ b/l0dables/Makefile
@@ -1,5 +1,5 @@
-C1D=blinky.c1d invaders.c1d mandel.c1d snake.c1d bricks.c1d schedule.c1d ws2812b.c1d
-N1K=nick_scr0ll.n1k nick_w0rpcore.n1k nick_matrix.n1k nick_plain.n1k nick_invaders.n1k nick_anim.n1k nick_image.n1k nick_life.n1k nick_colplasm.n1k nick_ledbow.n1k
+C1D=suskinick.c1d bergienick.c1d blinky.c1d invaders.c1d mandel.c1d snake.c1d bricks.c1d schedule.c1d ws2812b.c1d
+N1K=suskinick.n1k bergienick.n1k nick_scr0ll.n1k nick_w0rpcore.n1k nick_matrix.n1k nick_plain.n1k nick_invaders.n1k nick_anim.n1k nick_image.n1k nick_life.n1k nick_colplasm.n1k nick_ledbow.n1k
 
 TABLEFILES=jumptable.c jumptable.h usetable.h
 
@@ -8,9 +8,12 @@ l0dables: usetable.h $(C1D) $(N1K)
 CFLAGS=-Wno-unused-variable -DRAD1O -DLPC43XX_M4 -DL0DABLE
 CFLAGS+=-mlong-calls # XXX: do we need those?
 
+
 LDSCRIPT=../ld/l0dable.ld
 RPATH=..
 include ../Makefile.inc
+
+OBJS = ../rad1olib/setup.o
 
 $(TABLEFILES): EXPORTS mktable.pl
 	./mktable.pl

--- a/l0dables/bergienick.c
+++ b/l0dables/bergienick.c
@@ -1,0 +1,146 @@
+#include <stdint.h>
+#include <string.h>
+
+#include <r0ketlib/display.h>
+#include <r0ketlib/fonts.h>
+#include <r0ketlib/render.h>
+#include <r0ketlib/fonts/smallfonts.h>
+#include <r0ketlib/keyin.h>
+#include <r0ketlib/itoa.h>
+#include <r0ketlib/config.h>
+#include <r0ketlib/print.h>
+#include <rad1olib/pins.h>
+#include <rad1olib/light_ws2812_cortex.h>
+#include <rad1olib/setup.h>
+#include <r0ketlib/display.h>
+#include <r0ketlib/image.h>
+
+
+#include "usetable.h"
+
+void dim(uint8_t *target, uint8_t *colours, size_t size, int dimmingfactor){
+	for(int i= 0; i < size; i++){
+		target[i] = colours[i]/dimmingfactor ;
+	};
+
+};
+
+void ram(void) {
+  int dimmingfactor = 10;
+  int dx=0;
+  int dy=0;
+    static uint32_t ctr=0;
+  ctr++;
+	uint8_t pattern[] = {
+                     0, 0, 0,
+                     0, 0, 0,
+
+                     0,   0,   204,
+                     0,   51,   204,
+                     0,   102,   204,
+                     0,   153,   204,
+                     0,   204,   204,
+                     0, 255,   204
+                     };
+    
+    uint8_t green[] = {
+                      255, 0, 0,
+                      255, 0, 0,
+        
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0
+                      };
+     uint8_t red[] = {
+                      0, 255, 0,
+                      0, 255, 0,
+        
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0
+                      };
+
+	uint8_t blue[] = {
+			0,0,255,
+			0,0,255,
+
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255
+			};
+	uint8_t off[] = {
+			0,0,0,
+			0,0,0,
+
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0
+			};
+	uint8_t  dimmer[] = {
+	                0,0,0,
+                        0,0,0,
+
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0
+			};
+    getInputWaitRelease();
+	SETUPgout(RGB_LED);
+
+  setExtFont(GLOBAL(nickfont));
+  dx=DoString(0,0,GLOBAL(nickname));
+    dx=(RESX-dx)/2;
+    if(dx<0)
+        dx=0;
+    dy=(RESY-getFontHeight())/2;
+
+  lcdShowImageFile("nick.lcd");
+
+  getInputWait();
+  setTextColor(0xFF,0x00);
+    
+    
+    while(1){
+	
+		switch(getInput()){
+			case BTN_UP:
+		dim(dimmer, pattern, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_DOWN:
+		dim(dimmer, green, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_LEFT:
+		dim(dimmer, red, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_RIGHT:
+		dim(dimmer, blue, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_ENTER:
+		ws2812_sendarray(off, sizeof(off));
+				return;
+				break;
+		};
+	};
+    
+  return;
+  
+}

--- a/l0dables/suskinick.c
+++ b/l0dables/suskinick.c
@@ -1,0 +1,150 @@
+#include <stdint.h>
+#include <string.h>
+
+#include <r0ketlib/display.h>
+#include <r0ketlib/fonts.h>
+#include <r0ketlib/render.h>
+#include <r0ketlib/fonts/smallfonts.h>
+#include <r0ketlib/keyin.h>
+#include <r0ketlib/itoa.h>
+#include <r0ketlib/config.h>
+#include <r0ketlib/print.h>
+#include <rad1olib/pins.h>
+#include <rad1olib/light_ws2812_cortex.h>
+#include <rad1olib/setup.h>
+#include <r0ketlib/display.h>
+
+
+#include "usetable.h"
+
+void dim(uint8_t *target, uint8_t *colours, size_t size, int dimmingfactor){
+	for(int i= 0; i < size; i++){
+		target[i] = colours[i]/dimmingfactor ;
+	};
+
+};
+
+void ram(void) {
+  int dimmingfactor = 10;
+  int dx=0;
+  int dy=0;
+    static uint32_t ctr=0;
+  ctr++;
+	uint8_t pattern[] = {
+                     0, 0, 0,
+                     0, 0, 0,
+
+                     0,   0,   204,
+                     0,   51,   204,
+                     0,   102,   204,
+                     0,   153,   204,
+                     0,   204,   204,
+                     0, 255,   204
+                     };
+    
+    uint8_t green[] = {
+                      255, 0, 0,
+                      255, 0, 0,
+        
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0,
+                      255, 0, 0
+                      };
+     uint8_t red[] = {
+                      0, 255, 0,
+                      0, 255, 0,
+        
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0,
+                      0, 255, 0
+                      };
+
+	uint8_t blue[] = {
+			0,0,255,
+			0,0,255,
+
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255,
+			0,0,255
+			};
+	uint8_t off[] = {
+			0,0,0,
+			0,0,0,
+
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0,
+			0,0,0
+			};
+	uint8_t  dimmer[] = {
+	                0,0,0,
+                        0,0,0,
+
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0,
+                        0,0,0
+			};
+    getInputWaitRelease();
+	SETUPgout(RGB_LED);
+
+  setExtFont(GLOBAL(nickfont));
+  dx=DoString(0,0,GLOBAL(nickname));
+    dx=(RESX-dx)/2;
+    if(dx<0)
+        dx=0;
+    dy=(RESY-getFontHeight())/2;
+
+  lcdClear();
+  lcdFill(GLOBAL(nickbg));
+  setTextColor(GLOBAL(nickbg),GLOBAL(nickfg));
+  lcdSetCrsr(dx,dy);
+  lcdPrintln(GLOBAL(nickname));
+  lcdDisplay();
+
+  getInputWait();
+  setTextColor(0xFF,0x00);
+    
+    
+    while(1){
+	
+		switch(getInput()){
+			case BTN_UP:
+		dim(dimmer, pattern, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_DOWN:
+		dim(dimmer, green, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_LEFT:
+		dim(dimmer, red, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_RIGHT:
+		dim(dimmer, blue, sizeof(dimmer), dimmingfactor);
+                ws2812_sendarray(dimmer, sizeof(dimmer));
+				break;
+			case BTN_ENTER:
+		ws2812_sendarray(off, sizeof(off));
+				return;
+				break;
+		};
+	};
+    
+  return;
+  
+}


### PR DESCRIPTION
The `suskinick` l0adable has LED interaction activated by the joystick _and_ shows the user's nick. `bergienick` is adaptation of that that shows an image named `nick.lcd`.

LED states with these l0adables:
- Initial: off
- Up: antenna LEDs purple
- Down: all LEDs green
- Right: all LEDs blue
- Left: all LEDs red
- Click: close the l0adable

Contains #57 LED stuff and `suskinick` loadable from https://github.com/cannonerd/f1rmware
