### PR TITLE
Bugfix for left button behaviour

### DIFF
--- a/l0dables/ws2812b.c
+++ b/l0dables/ws2812b.c
@@ -38,7 +38,7 @@ void ram(void){
                     redraw(--brightness);
                 break;
             case BTN_LEFT:
-                return;
+                break;
             case BTN_RIGHT:
                 break;
             case BTN_ENTER:


### PR DESCRIPTION
The left button also closed the app and isn't ignored like the right button. The left button acts like the Enter which it is not supposed to.
