### PR TITLE
Macro for converting 24-bit rgb colors into r0cket 8-bit colors

### DIFF
--- a/r0ketlib/display.h
+++ b/r0ketlib/display.h
@@ -9,6 +9,8 @@
 #define TYPE_CMD    0
 #define TYPE_DATA   1
 
+#define RGB(rgb) (rgb & 0b111000000000000000000000) >> 16 | (rgb & 0b000000001110000000000000) >> 11 | (rgb & 0b000000000000000011000000) >> 6
+
 /* Display buffer */
 extern uint8_t lcdBuffer[RESX*RESY];
 

--- a/testapp/lcd.c
+++ b/testapp/lcd.c
@@ -7,7 +7,7 @@
 #include <rad1olib/setup.h>
 #include <r0ketlib/display.h>
 
-
+#undef RGB
 #define RGB1(r,g,b) (((r)&0b11111000)|((g)>>5))
 #define RGB2(r,g,b) (((g)&0b00011100)<<3|((b)>>3))
 #define RGB(r,g,b) ((RGB1(r,g,b)<<8) | RGB2(r,g,b))


### PR DESCRIPTION
Getting the right color for the rad1o can be tedious. This macro allows usage of familliar 24-bit colors which will be converted to the closest r0cket color.
