### PR TITLE
Reshuffle memory to allow mod files up to 72KB

### DIFF
--- a/musicapp/Makefile
+++ b/musicapp/Makefile
@@ -29,7 +29,7 @@ OBJS += $(SOBJS)
 
 CFLAGS=-Wno-unused-variable -DRAD1O -DLPC43XX_M4
 
-LDSCRIPT=../ld/app.ld
+LDSCRIPT=app.ld
 RPATH=..
 include ../Makefile.inc
 

--- a/musicapp/app.ld
+++ b/musicapp/app.ld
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2012 Michael Ossmann <mike@ossmann.com>
+ * Copyright (C) 2012 Benjamin Vernoux <titanmkd@gmail.com>
+ * Copyright (C) 2012 Jared Boone <jared@sharebrained.com>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Generic linker script for LPC43XX targets using libopencm3. */
+
+/* Memory regions must be defined in the ld script which includes this one. */
+
+/* Enforce emmission of the vector table. */
+EXTERN (vector_table)
+EXTERN (JumpTable)
+
+/* Define the entry point of the output file. */
+ENTRY(reset_handler)
+
+/* Define sections. */
+SECTIONS
+{
+	.vect : {
+		_text_ram = 0; /* Start of Code in RAM NULL because Copy of Code from ROM to RAM disabled */
+		. = ALIGN(0x400);
+		*(.vectors)	/* Vector table */
+	} > ram_local1
+
+	.jump : {
+		KEEP(*(.jump))	/* Jump table */
+	} > ram_local1
+
+	.text : {
+		*(.text*)	/* Program code */
+		. = ALIGN(4);
+		*(.rodata*)	/* Read-only data */
+		. = ALIGN(4);
+	} >ram_local1
+
+	/* C++ Static constructors/destructors, also used for __attribute__
+	 * ((constructor)) and the likes */
+	.preinit_array : {
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+	} >ram_local1
+	.init_array : {
+		. = ALIGN(4);
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+	} >ram_local1
+	.fini_array : {
+		. = ALIGN(4);
+		__fini_array_start = .;
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		__fini_array_end = .;
+	} >ram_local1
+
+	/*
+	 * Another section used by C++ stuff, appears when using newlib with
+	 * 64bit (long long) printf support
+	 */
+	.ARM.extab : {
+		*(.ARM.extab*)
+	} >ram_local1
+    
+	/* exception index - required due to libgcc.a issuing /0 exceptions */
+	.ARM.exidx : {
+		__exidx_start = .;
+		*(.ARM.exidx*)
+		__exidx_end = .;
+	} >ram_local1
+
+	. = ALIGN(4);
+	_etext = .;
+	_etext_ram = 0; /* Start of Code in RAM NULL because Copy of Code from ROM to RAM disabled */
+	_etext_rom = 0; /* Start of Code in RAM NULL because Copy of Code from ROM to RAM disabled */
+
+	.data : {
+		_data = .;
+		*(.data*)	/* Read-write initialized data */
+		. = ALIGN(4);
+		_edata = .;
+	} >ram_local1
+	_data_loadaddr = LOADADDR(.data);
+
+/*	_data_rom = LOADADDR (.data) + ORIGIN(rom);
+	_edata_rom = _data_rom + SIZEOF (.data); */
+
+	.bss : {
+		_bss = .;
+		*(.bss*)	/* Read-write zero initialized data */
+		*(COMMON)
+		. = ALIGN(4);
+		_ebss = .;
+	} >ram_local1
+
+	/* exception unwind data - required due to libgcc.a issuing /0 exceptions */
+	.ARM.extab : {
+		*(.ARM.extab*)
+	} >ram_local1
+
+	/*
+	 * The .eh_frame section appears to be used for C++ exception handling.
+	 * You may need to fix this if you're using C++.
+	 */
+	/DISCARD/ : { *(.eh_frame) }
+
+	. = ALIGN(4);
+	_end = .;
+
+	/* Leave room above stack for IAP to run. */
+	__StackTop = ORIGIN(ram_local1) + LENGTH(ram_local1) - 32;
+	PROVIDE(_stack = __StackTop);
+	_l0dable_start = ORIGIN(ram_l0dable);
+	_l0dable_len = LENGTH(ram_l0dable);
+	_jumptable_len = SIZEOF(.jump);
+}

--- a/musicapp/music.c
+++ b/musicapp/music.c
@@ -34,13 +34,14 @@
 #include <libopencm3/cm3/vector.h>
 
 // about 32kByte AHB RAM designated for Cortex M0 @ 0x20000000,
-// we mis-use it for our buffers
-#define MODFILE_BUF_SIZE (32*1024)
-#define MODFILE_BUF 0x20000000
+// we mis-use it for our samples
+#define SAMPLES_BANK_SIZE (32*1024)
+#define SAMPLES_BUF 0x20000000
 
-// 16kByte in ram_l0dable section
-#define SAMPLES_BANK_SIZE (8*1024)
-#define SAMPLES_BUF 0x10080000
+// The mod buffer can go in the second RAM segment. This relies
+// on a modified linker script to move everything else away from here.
+#define MODFILE_BUF_SIZE (72*1024)
+#define MODFILE_BUF 0x10080000
 
 // we can work with 51MHz just fine.
 #define RITIMER_RATE 51000000


### PR DESCRIPTION
I thought 32KB was a bit small. Have some more space for mod files, and more space for samples too.
