### PR TITLE
n1k for showing image and some LED states governed by joystick

### DIFF
--- a/l0dables/Makefile
+++ b/l0dables/Makefile
@@ -1,5 +1,5 @@
 C1D=cube.c1d blinky.c1d invaders.c1d mandel.c1d snake.c1d snake2.c1d bricks.c1d schedule.c1d ws2812b.c1d battery.c1d fire.c1d colorp.c1d
-N1K=nick_scr0ll.n1k nick_w0rpcore.n1k nick_matrix.n1k nick_plain.n1k nick_invaders.n1k nick_anim.n1k nick_image.n1k nick_life.n1k nick_colplasm.n1k nick_ledbow.n1k
+N1K=nick_scr0ll.n1k nick_w0rpcore.n1k nick_matrix.n1k nick_plain.n1k nick_invaders.n1k nick_anim.n1k nick_image.n1k nick_life.n1k nick_colplasm.n1k nick_ledbow.n1k nick_ledimage.n1k
 
 TABLEFILES=jumptable.c jumptable.h usetable.h
 

--- a/l0dables/nick_ledimage.c
+++ b/l0dables/nick_ledimage.c
@@ -26,9 +26,7 @@ void dim(uint8_t *target, uint8_t *colours, size_t size, int dimmingfactor){
 
 void ram(void) {
   int dimmingfactor = 10;
-  int dx=0;
-  int dy=0;
-    static uint32_t ctr=0;
+  static uint32_t ctr=0;
   ctr++;
   uint8_t pattern[] = {
     0, 0, 0,
@@ -99,13 +97,6 @@ void ram(void) {
   };
   getInputWaitRelease();
   SETUPgout(RGB_LED);
-
-  setExtFont(GLOBAL(nickfont));
-  dx=DoString(0,0,GLOBAL(nickname));
-    dx=(RESX-dx)/2;
-    if(dx<0)
-        dx=0;
-    dy=(RESY-getFontHeight())/2;
 
   if (lcdShowImageFile("nick.lcd") != 0) {
     lcdClear();

--- a/l0dables/nick_ledimage.c
+++ b/l0dables/nick_ledimage.c
@@ -1,0 +1,150 @@
+#include <stdint.h>
+#include <string.h>
+
+#include <r0ketlib/display.h>
+#include <r0ketlib/fonts.h>
+#include <r0ketlib/render.h>
+#include <r0ketlib/fonts/smallfonts.h>
+#include <r0ketlib/keyin.h>
+#include <r0ketlib/itoa.h>
+#include <r0ketlib/config.h>
+#include <r0ketlib/print.h>
+#include <rad1olib/pins.h>
+#include <rad1olib/light_ws2812_cortex.h>
+#include <rad1olib/setup.h>
+#include <r0ketlib/display.h>
+#include <r0ketlib/image.h>
+
+
+#include "usetable.h"
+
+void dim(uint8_t *target, uint8_t *colours, size_t size, int dimmingfactor){
+  for(int i= 0; i < size; i++){
+    target[i] = colours[i]/dimmingfactor ;
+  };
+};
+
+void ram(void) {
+  int dimmingfactor = 10;
+  int dx=0;
+  int dy=0;
+    static uint32_t ctr=0;
+  ctr++;
+  uint8_t pattern[] = {
+    0, 0, 0,
+    0, 0, 0,
+
+    0, 0, 204,
+    0, 51, 204,
+    0, 102, 204,
+    0, 153, 204,
+    0, 204, 204,
+    0, 255, 204
+  };
+
+  uint8_t green[] = {
+    255, 0, 0,
+    255, 0, 0,
+
+    255, 0, 0,
+    255, 0, 0,
+    255, 0, 0,
+    255, 0, 0,
+    255, 0, 0,
+    255, 0, 0
+  };
+  uint8_t red[] = {
+    0, 255, 0,
+    0, 255, 0,
+
+    0, 255, 0,
+    0, 255, 0,
+    0, 255, 0,
+    0, 255, 0,
+    0, 255, 0,
+    0, 255, 0
+  };
+  uint8_t blue[] = {
+    0,0,255,
+    0,0,255,
+
+    0,0,255,
+    0,0,255,
+    0,0,255,
+    0,0,255,
+    0,0,255,
+    0,0,255
+  };
+  uint8_t off[] = {
+    0,0,0,
+    0,0,0,
+
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0
+  };
+  uint8_t  dimmer[] = {
+    0,0,0,
+    0,0,0,
+
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0,
+    0,0,0
+  };
+  getInputWaitRelease();
+  SETUPgout(RGB_LED);
+
+  setExtFont(GLOBAL(nickfont));
+  dx=DoString(0,0,GLOBAL(nickname));
+    dx=(RESX-dx)/2;
+    if(dx<0)
+        dx=0;
+    dy=(RESY-getFontHeight())/2;
+
+  if (lcdShowImageFile("nick.lcd") != 0) {
+    lcdClear();
+    lcdNl();
+    lcdPrintln("File nick.lcd");
+    lcdPrintln("not present.");
+    lcdNl();
+    lcdDisplay();
+  }
+
+  getInputWait();
+  setTextColor(0xFF,0x00);
+
+  while(1){
+    char key = getInputRaw();
+    switch(key){
+      case BTN_UP:
+        dim(dimmer, pattern, sizeof(dimmer), dimmingfactor);
+            ws2812_sendarray(dimmer, sizeof(dimmer));
+        break;
+      case BTN_DOWN:
+        dim(dimmer, green, sizeof(dimmer), dimmingfactor);
+            ws2812_sendarray(dimmer, sizeof(dimmer));
+        break;
+      case BTN_LEFT:
+        dim(dimmer, red, sizeof(dimmer), dimmingfactor);
+            ws2812_sendarray(dimmer, sizeof(dimmer));
+        break;
+      case BTN_RIGHT:
+        dim(dimmer, blue, sizeof(dimmer), dimmingfactor);
+            ws2812_sendarray(dimmer, sizeof(dimmer));
+        break;
+      case BTN_ENTER:
+        lcd_deselect();
+        ws2812_sendarray(off, sizeof(off));
+        return;
+    };
+  };
+    
+  return;
+  
+}


### PR DESCRIPTION
`nick_ledimage` shows an image named `nick.lcd` and provides some LED colors governed by the joystick.

LED states with these l0adables:
- Initial: off
- Up: antenna LEDs purple
- Down: all LEDs green
- Right: all LEDs blue
- Left: all LEDs red
- Click: close the l0adable

Replaces #56 with a cleaner setup. LED interaction is the same as in #57 but with some tweaks to make it work as a n1k animation.
