### PR TITLE
fix convertleds.py with python3

### DIFF
--- a/tools/convertleds.py
+++ b/tools/convertleds.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 import sys
 import binascii
 import struct


### PR DESCRIPTION
fixes errors with python3

```
TypeError: must be str, not bytes  
Traceback (most recent call last):  
  File "../tools/convertleds.py", line 42, in <module>  
    fpW.write(struct.pack('>H', delay))`
```
