### PR TITLE
Register spectrum callback, cleanup, fixed implicit declaration warnings

### DIFF
--- a/portalib/portapack.c
+++ b/portalib/portapack.c
@@ -127,16 +127,6 @@ static void rx_ais_init_wrapper(void* const _state) {
 
 static volatile receiver_baseband_handler_t receiver_baseband_handler = NULL;
 
-typedef enum {
-	RECEIVER_CONFIGURATION_SPEC = 0,
-	RECEIVER_CONFIGURATION_NBAM = 1,
-	RECEIVER_CONFIGURATION_NBFM = 2,
-	RECEIVER_CONFIGURATION_WBFM = 3,
-	RECEIVER_CONFIGURATION_TPMS = 4,
-	RECEIVER_CONFIGURATION_TPMS_FSK = 5,
-	RECEIVER_CONFIGURATION_AIS = 6,
-} receiver_configuration_id_t;
-
 typedef struct receiver_configuration_t {
 	receiver_state_init_t init;
 	receiver_baseband_handler_t baseband_handler;

--- a/portalib/portapack.h
+++ b/portalib/portapack.h
@@ -71,6 +71,17 @@ typedef struct device_state_t {
 	dsp_metrics_t dsp_metrics;
 } device_state_t;
 
+typedef enum {
+	RECEIVER_CONFIGURATION_SPEC = 0,
+	RECEIVER_CONFIGURATION_NBAM = 1,
+	RECEIVER_CONFIGURATION_NBFM = 2,
+	RECEIVER_CONFIGURATION_WBFM = 3,
+	RECEIVER_CONFIGURATION_TPMS = 4,
+	RECEIVER_CONFIGURATION_TPMS_FSK = 5,
+	RECEIVER_CONFIGURATION_AIS = 6,
+} receiver_configuration_id_t;
+
+
 void portapack_init();
 void portapack_run();
 

--- a/portalib/specan.h
+++ b/portalib/specan.h
@@ -32,4 +32,7 @@ void specan_init(void* const _state);
 void specan_baseband_handler(void* const _state, complex_s8_t* const in, const size_t sample_count_in, baseband_timestamps_t* const timestamps);
 void specan_acknowledge_frame(void* const _state);
 
+typedef void (*specan_callback_t)(uint8_t* buf, int bufLen);
+void specan_register_callback(specan_callback_t callback);
+
 #endif/*__SPECAN_H__*/

--- a/testapp/spectrum.c
+++ b/testapp/spectrum.c
@@ -14,20 +14,26 @@
 #include <rad1olib/pins.h>
 
 #include <portalib/portapack.h>
+#include <portalib/specan.h>
 #include <common/hackrf_core.h>
 #include <common/rf_path.h>
 #include <common/sgpio.h>
+#include <common/sgpio_dma.h>
 #include <common/tuning.h>
 #include <libopencm3/lpc43xx/dac.h>
 
 #include <portalib/complex.h>
 
-static volatile int64_t freq = 2450000000;
+#define DEFAULT_FREQ 2450000000
+#define DEFAULT_MODE MODE_SPECTRUM
+
+static volatile int64_t freq = DEFAULT_FREQ;
 
 #define MODE_SPECTRUM 10
 #define MODE_WATERFALL 20
 
-static volatile int displayMode = MODE_SPECTRUM;
+static volatile int displayMode = DEFAULT_MODE;
+
 void spectrum_callback(uint8_t* buf, int bufLen)
 {
 	TOGGLE(LED2);
@@ -88,6 +94,13 @@ void spectrum_menu()
 	cpu_clock_set(204); // WARP SPEED! :-)
 	si5351_init();
 	portapack_init();
+	
+	set_rx_mode(RECEIVER_CONFIGURATION_SPEC);
+	specan_register_callback(spectrum_callback);
+	
+	// defaults:
+	freq = DEFAULT_FREQ;
+	displayMode = DEFAULT_MODE;
 
 	while(1)
 	{
@@ -110,7 +123,7 @@ void spectrum_menu()
 				set_freq(freq);
 				break;
 			//case BTN_ENTER:
-				//FIXME: unset the callback, reset the clockspeed, tidy up
+				//specan_register_callback(0);
 				//return;
 
 		}

--- a/testapp/spectrum.c
+++ b/testapp/spectrum.c
@@ -105,7 +105,9 @@ void spectrum_init()
 
 void spectrum_stop()
 {
-	nvic_disable_irq(NVIC_DMA_IRQ);
+//	nvic_disable_irq(NVIC_DMA_IRQ);
+	sgpio_dma_stop();
+	sgpio_cpld_stream_disable();
 	OFF(EN_VDD);
 	OFF(EN_1V8);
 	ON(MIC_AMP_DIS);


### PR DESCRIPTION
(there were also some implicit declaration warnings fixed in the merges)
