### PR TITLE
fix for ld: cannot find -lc_nano

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -23,7 +23,7 @@
     * Arch: `sudo pacman -S arm-none-eabi-gcc arm-none-eabi-newlib arm-none-eabi-binutils`
     * FreeBSD: Theory: `sudo pkg install arm-none-eabi-gcc492 arm-none-eabi-binutils` / `portmaster devel/arm-none-eabi-gcc492 devel/arm-none-eabi-binutils`; practice: `kldload linux` & see _Manual installation_
     * Fedora: `sudo dnf install arm-none-eabi-newlib arm-none-eabi-gcc-cs-c++.x86_64 gcc-c++-arm-linux-gnu.x86_64`
-    ** note that while [https://bugzilla.redhat.com/show_bug.cgi?id=1248294](RHBZ #1248294] you will need to rebuild arm-none-eabi-newlib as descrived by the reporter. Or just use [https://blog.pcfe.net/packages/arm-none-eabi-newlib-2.2.0_1-4.fc24.noarch.rpm](my build).
+    ** note: [https://bugzilla.redhat.com/show_bug.cgi?id=1248294](RHBZ #1248294] you will need to rebuild arm-none-eabi-newlib as described by the reporter. Or just use [https://blog.pcfe.net/packages/arm-none-eabi-newlib-2.2.0_1-4.fc24.noarch.rpm](my build).
 * python-yaml (http://pyyaml.org/)
     * Debian/Ubuntu: `sudo apt-get install python-yaml`
     * Arch: `sudo pacman -S python-yaml`

--- a/doc/build.md
+++ b/doc/build.md
@@ -23,6 +23,7 @@
     * Arch: `sudo pacman -S arm-none-eabi-gcc arm-none-eabi-newlib arm-none-eabi-binutils`
     * FreeBSD: Theory: `sudo pkg install arm-none-eabi-gcc492 arm-none-eabi-binutils` / `portmaster devel/arm-none-eabi-gcc492 devel/arm-none-eabi-binutils`; practice: `kldload linux` & see _Manual installation_
     * Fedora: `sudo dnf install arm-none-eabi-newlib arm-none-eabi-gcc-cs-c++.x86_64 gcc-c++-arm-linux-gnu.x86_64`
+    ** note that while [https://bugzilla.redhat.com/show_bug.cgi?id=1248294](RHBZ #1248294] you will need to rebuild arm-none-eabi-newlib as descrived by the reporter. Or just use [https://blog.pcfe.net/packages/arm-none-eabi-newlib-2.2.0_1-4.fc24.noarch.rpm](my build).
 * python-yaml (http://pyyaml.org/)
     * Debian/Ubuntu: `sudo apt-get install python-yaml`
     * Arch: `sudo pacman -S python-yaml`


### PR DESCRIPTION
On Fedora there currently is  [https://bugzilla.redhat.com/show_bug.cgi?id=1248294](Bug 1248294 - nano libc is not included in package).
added bug link and link to rebuilt packages to build doc
