### PR TITLE
prefer the patched dfu-util if it's in ../../dfu-util/src/

### DIFF
--- a/smartflash/Makefile
+++ b/smartflash/Makefile
@@ -45,7 +45,7 @@ gather:
 	dd if=../bootloader/boot.b1n of=$(hdrimg) conv=notrunc
 
 run:
-	./FLASHgui
+	PATH="../../dfu-util/src/:${PATH}" ./FLASHgui
 
 ### Rebuild everything
 rebuild: build gather

--- a/smartflash/README.md
+++ b/smartflash/README.md
@@ -28,6 +28,7 @@ A few tools and files need to be installed. The f1rmware and all other files nee
 
 #### mtools
  - On arch: `pacman -S mtools`
+ - On Fedora `sudo dnf install mtools`
 
 #### Patched dfu-util
 The patched dfu-util provides support to flash more than one rad1o at a time.
@@ -42,10 +43,11 @@ make
 sudo cp src/dfu-util `which dfu-util`
 # or install
 sudo make install
+# or adjust $PATH
 ```
 #### udev rule:
  - Copy `90-rad1o-flash.rules` to `/etc/udev/rules.d`
- - reload rules ```$ sudo udevadm control --reload```
+ - reload rules `$ sudo udevadm control --reload`
 
 
 #### perl Curses module
@@ -59,6 +61,11 @@ apt-get install libcurses-perl
 
 ```
 pacman -S perl-curses
+```
+
+#####Fedora
+```
+sudo dnf install perl-Curses
 ```
 
 #####Directly from CPAN

--- a/smartflash/README.md
+++ b/smartflash/README.md
@@ -45,6 +45,7 @@ sudo make install
 ```
 #### udev rule:
  - Copy `90-rad1o-flash.rules` to `/etc/udev/rules.d`
+ - reload rules ```$ sudo udevadm control --reload```
 
 
 #### perl Curses module


### PR DESCRIPTION
Clunky change to Makefile so that it's sufficient to have checked out radio/dfu-util and built it, instead of overwriting the operating system's dfu-util
Obviously needs a git checkout of rad1o/dfu-util in the same parent directory where rad1o/f1rmware was checked out.  
Feel free to NACK if deemed too dirty of a work around.
