### PR TITLE
fix: rfapp: battery led status didn't work because not initialized

### DIFF
--- a/campapp/main.c
+++ b/campapp/main.c
@@ -152,8 +152,6 @@ int main(void) {
 
 	generated_init();
 
-    init_nick();
-
     // XXX: TODO!
     // randomInit();
 

--- a/campapp/nickname.c
+++ b/campapp/nickname.c
@@ -50,6 +50,7 @@ void fancyNickname(void) {
 
 /**************************************************************************/
 
+// every function name starting with init_ is added to generated_init automatically
 void init_nick(void){
 	readTextFile("nick.cfg",GLOBAL(nickname),MAXNICK);
 	readTextFile("font.cfg",GLOBAL(nickfont),FLEN);

--- a/rfapp/main.c
+++ b/rfapp/main.c
@@ -76,6 +76,7 @@ int main(void) {
 	fsInit();
 	lcdFill(0xff);
 	readConfig();
+	batteryInit();
 
 	generated_init();
 

--- a/rfapp/main.c
+++ b/rfapp/main.c
@@ -11,9 +11,11 @@
 #include <r0ketlib/keyin.h>
 #include <r0ketlib/menu.h>
 #include <r0ketlib/config.h>
+#include <r0ketlib/config.h>
 
 #include <rad1olib/pins.h>
 #include <rad1olib/systick.h>
+#include <rad1olib/battery.h>
 
 #include <r0ketlib/fs_util.h>
 
@@ -22,7 +24,7 @@
 
 #define EVERY(x,y) if((ctr+y)%(x/SYSTICKSPEED)==0)
 
-void night_tick(void){
+void tick_batteryLED(void){
     static int ctr;
     ctr++;
 
@@ -50,7 +52,6 @@ void night_tick(void){
 
 void sys_tick_handler(void){
 	incTimer();
-	night_tick();
 	generated_tick();
 };
 

--- a/rfapp/spectrum.c
+++ b/rfapp/spectrum.c
@@ -107,10 +107,6 @@ void spectrum_init()
 
 	// defaults:
 
-	// the frequency is either initialized to DEFAULT_FREQ or set by the frequency menu
-	// resetting it here would break the menu.
-	//freq = DEFAULT_FREQ;
-
 	displayMode = DEFAULT_MODE;
 }
 

--- a/rfapp/spectrum.c
+++ b/rfapp/spectrum.c
@@ -148,43 +148,45 @@ void spectrum_show()
 		{
 			case BTN_UP:
 				displayMode=MODE_WATERFALL;
-                while(getInputRaw()==BTN_UP)
-                    ;
+				while(getInputRaw()==BTN_UP)
+					;
 				break;
 			case BTN_DOWN:
 				displayMode=MODE_SPECTRUM;
-                while(getInputRaw()==BTN_DOWN)
-                    ;
+				while(getInputRaw()==BTN_DOWN)
+					;
 				break;
 			case BTN_LEFT:
-        buttonPressTime = _timectr;
+				buttonPressTime = _timectr;
 				freq -= 2000000;
 				ssp1_set_mode_max2837();
 				set_freq(freq);
-                while(getInputRaw()==BTN_LEFT){
-                    if (_timectr > buttonPressTime + FAST_CHANGE_DELAY/SYSTICKSPEED)
-                    {
-                        freq -= FAST_CHANGE_CHANGE;
-                        ssp1_set_mode_max2837();
-                        set_freq(freq);
-                        delayms(10);
-                    }
-                }
+				while(getInputRaw()==BTN_LEFT)
+				{
+					if (_timectr > buttonPressTime + FAST_CHANGE_DELAY/SYSTICKSPEED)
+					{
+						freq -= FAST_CHANGE_CHANGE;
+						ssp1_set_mode_max2837();
+						set_freq(freq);
+						delayms(10);
+					}
+				}
 				break;
 			case BTN_RIGHT:
-        buttonPressTime = _timectr;
+				buttonPressTime = _timectr;
 				freq += 2000000;
 				ssp1_set_mode_max2837();
 				set_freq(freq);
-                while(getInputRaw()==BTN_RIGHT){
-                    if (_timectr > buttonPressTime + FAST_CHANGE_DELAY/SYSTICKSPEED)
-                    {
-                        freq += FAST_CHANGE_CHANGE;
-                        ssp1_set_mode_max2837();
-                        set_freq(freq);
-                        delayms(10);
-                    }
-                }
+				while(getInputRaw()==BTN_RIGHT)
+				{
+					if (_timectr > buttonPressTime + FAST_CHANGE_DELAY/SYSTICKSPEED)
+					{
+						freq += FAST_CHANGE_CHANGE;
+						ssp1_set_mode_max2837();
+						set_freq(freq);
+						delayms(10);
+					}
+				}
 				break;
 			case BTN_ENTER:
 				spectrum_stop();


### PR DESCRIPTION
The code to show battery state on led4 was present but not working because the init function was not called. (Note that you need to configure this first in campapp).
