### PR TITLE
fix(ssp): Clean up the usage of DIVC

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -197,7 +197,6 @@ void bootFile(const char * filename){
 
 int main(uint32_t startloc) {
 	cpuClockInit();
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);

--- a/campapp/main.c
+++ b/campapp/main.c
@@ -121,7 +121,6 @@ void fancyNickname(void);
 
 int main(void) {
 	cpuClockInit(); /* CPU Clock is now 104 MHz */
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);

--- a/ccccmaze/main.c
+++ b/ccccmaze/main.c
@@ -26,7 +26,6 @@ void sys_tick_handler(void){
 
 int main(void) {
 	cpu_clock_init(); /* CPU Clock is now 104 MHz */
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);

--- a/feldtest/main.c
+++ b/feldtest/main.c
@@ -97,7 +97,6 @@ void si_en(){
 
 int main(void) {
 	cpu_clock_init_();
-	ssp_clock_init();
 
 	systickInit();
 

--- a/flashapp/main.c
+++ b/flashapp/main.c
@@ -110,7 +110,6 @@ void full_msc(){
 
 int main(void) {
     cpuClockInit(); /* CPU Clock is now 104 MHz */
-    ssp_clock_init();
     systickInit();
 
     SETUPgout(EN_VDD);

--- a/imglcd/main.c
+++ b/imglcd/main.c
@@ -70,7 +70,6 @@ void doLCD();
 int main(void)
 {
 	cpu_clock_init_();
-	ssp_clock_init();
 
 	inputInit();
 

--- a/musicapp/main.c
+++ b/musicapp/main.c
@@ -28,7 +28,6 @@ void sys_tick_handler(void){
 
 int main(void) {
 	cpuClockInit(); /* CPU Clock is now 104 MHz */
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);

--- a/r0ketlib/display.c
+++ b/r0ketlib/display.c
@@ -18,13 +18,17 @@ uint8_t displayType;
 static char isTurned;
 
 void lcd_select() {
-    /* the LCD requires 9-Bit frames */
-    // Freq = PCLK / (CPSDVSR * [SCR+1])
-	/* we want 120ns / bit -> 8.3 MHz. */
-	/* SPI1 BASE CLOCK should be 40.8 MHz, CPSDVSR minimum is 2 */
-	/* so we run at SCR=1 => =~ 10MHz */
+    /*
+     * The LCD requires 9-Bit frames
+     * Freq = PCLK / (CPSDVSR * [SCR+1])
+	 * We want 120ns / bit -> 8.3 MHz.
+	 * SPI1 BASE CLOCK is expected to be 204 MHz.
+     * 204 MHz / ( 12 * (1 + 1)) = 8.5 MHz
+     *
+     * Set CPSDVSR = 12
+    */
     uint8_t serial_clock_rate = 1;
-    uint8_t clock_prescale_rate = 2;
+    uint8_t clock_prescale_rate = 12;
 
     ssp_init(LCD_SSP,
             SSP_DATA_9BITS,

--- a/rad1olib/setup.c
+++ b/rad1olib/setup.c
@@ -71,28 +71,22 @@ void cpuClockInit(void) {
 		| CGU_IDIVB_CTRL_IDIV(2-1)
 		| CGU_IDIVB_CTRL_PD(0)
 		;
-	_cpu_speed=102;
 
 	/* use DIV B as main clock */
 	/* This means, that possible speeds in MHz are:
 	 * 204 102 68 51 40.8 34 29.14 25.5 22.66 20.4 18.54 17 15.69 14.57 13.6 12.75
 	 */
-
 	CGU_BASE_M4_CLK = (CGU_BASE_M4_CLK_CLK_SEL(CGU_SRC_IDIVB) | CGU_BASE_M4_CLK_AUTOBLOCK(1));
+	_cpu_speed=102;
 
-	delayNop(WAIT_CPU_CLOCK_INIT_DELAY); /* should be 50us / 5100 @ 102MhZ */
-};
-
-void ssp_clock_init(void) {
-	/* set DIV C to 40.8 MHz */
+	/* set DIV C to 68 MHz. Used for SPIFI */
 	CGU_IDIVC_CTRL= CGU_IDIVC_CTRL_CLK_SEL(CGU_SRC_PLL1)
 		| CGU_IDIVC_CTRL_AUTOBLOCK(1) 
-		| CGU_IDIVC_CTRL_IDIV(5-1)
+		| CGU_IDIVC_CTRL_IDIV(3-1)
 		| CGU_IDIVC_CTRL_PD(0)
 		;
 
-	/* use DIV C as SSP1 base clock */
-	CGU_BASE_SSP1_CLK = (CGU_BASE_SSP1_CLK_CLK_SEL(CGU_SRC_IDIVC) | CGU_BASE_SSP1_CLK_AUTOBLOCK(1));
+	delayNop(WAIT_CPU_CLOCK_INIT_DELAY); /* should be 50us / 5100 @ 102MhZ */
 };
 
 /* Warning: changing from < 102MHz to >102 MHz in one step hangs */

--- a/rad1olib/setup.c
+++ b/rad1olib/setup.c
@@ -65,11 +65,20 @@ void cpuClockInit(void) {
 	/* Wait for PLL Lock */
 	while (!(CGU_PLL1_STAT & CGU_PLL1_STAT_LOCK_MASK));
 
-	/* set DIV B to 102 MHz */
+	/* set DIV B to 102 MHz. Used for base M4 clock.
+     * The frequency might vary over time.
+     * See cpu_clock_set() */
 	CGU_IDIVB_CTRL= CGU_IDIVB_CTRL_CLK_SEL(CGU_SRC_PLL1)
 		| CGU_IDIVB_CTRL_AUTOBLOCK(1) 
 		| CGU_IDIVB_CTRL_IDIV(2-1)
 		| CGU_IDIVB_CTRL_PD(0)
+		;
+
+	/* set DIV C to 68 MHz. Used for SPIFI */
+	CGU_IDIVC_CTRL= CGU_IDIVC_CTRL_CLK_SEL(CGU_SRC_PLL1)
+		| CGU_IDIVC_CTRL_AUTOBLOCK(1) 
+		| CGU_IDIVC_CTRL_IDIV(3-1)
+		| CGU_IDIVC_CTRL_PD(0)
 		;
 
 	/* use DIV B as main clock */
@@ -78,13 +87,6 @@ void cpuClockInit(void) {
 	 */
 	CGU_BASE_M4_CLK = (CGU_BASE_M4_CLK_CLK_SEL(CGU_SRC_IDIVB) | CGU_BASE_M4_CLK_AUTOBLOCK(1));
 	_cpu_speed=102;
-
-	/* set DIV C to 68 MHz. Used for SPIFI */
-	CGU_IDIVC_CTRL= CGU_IDIVC_CTRL_CLK_SEL(CGU_SRC_PLL1)
-		| CGU_IDIVC_CTRL_AUTOBLOCK(1) 
-		| CGU_IDIVC_CTRL_IDIV(3-1)
-		| CGU_IDIVC_CTRL_PD(0)
-		;
 
 	delayNop(WAIT_CPU_CLOCK_INIT_DELAY); /* should be 50us / 5100 @ 102MhZ */
 };

--- a/rad1olib/setup.h
+++ b/rad1olib/setup.h
@@ -32,7 +32,6 @@ extern uint8_t _cpu_speed;
 void delayNop(uint32_t duration);
 
 void cpuClockInit(void);
-void ssp_clock_init(void);
 void cpu_clock_set(uint32_t target_mhz);
 void usb_clock_init(void);
 void hackrf_clock_init(void);

--- a/rad1olib/spi-flash.c
+++ b/rad1olib/spi-flash.c
@@ -98,13 +98,8 @@ void flashInit(void){
 	SETUPpin(SPIFI_MOSI);
 	SETUPpin(SPIFI_CS);
 
-	/* Use DIV C for flash: 204/3 = 68 MHz
+    /* DIVC is expexted to be at 68 MHz.
 	   the flash could go up to 104, but that produces bit errors */
-	CGU_IDIVC_CTRL= CGU_IDIVC_CTRL_CLK_SEL(CGU_SRC_PLL1)
-		| CGU_IDIVC_CTRL_AUTOBLOCK(1) 
-		| CGU_IDIVC_CTRL_IDIV(3-1)
-		| CGU_IDIVC_CTRL_PD(0)
-		;
 	CGU_BASE_SPIFI_CLK = CGU_BASE_SPIFI_CLK_CLK_SEL(CGU_SRC_IDIVC);
 
 	/* config SPIFI, use defaults */

--- a/rfapp/main.c
+++ b/rfapp/main.c
@@ -56,7 +56,6 @@ void sys_tick_handler(void){
 
 int main(void) {
 	cpuClockInit(); /* CPU Clock is now 104 MHz */
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);

--- a/rfapp/telegraf.c
+++ b/rfapp/telegraf.c
@@ -466,7 +466,6 @@ void main_ui(void) {
     ssp1_init();
 
     lcdInit();
-    ssp_clock_init();
     render_display();
 
     max2837_stop();
@@ -496,7 +495,6 @@ void main_ui(void) {
                 g_freq = 2590000000U + (500000 * g_channel);
 
                 /* Select the lcd display. */
-                ssp_clock_init();
                 render_display();
 
                 /* Select the max2837. */
@@ -532,7 +530,6 @@ void main_ui(void) {
                 g_freq = 2590000000U + (500000 * g_channel);
 
                 /* Update the lcd display. */
-                ssp_clock_init();
                 render_display();
 
                 if (g_current_mode == TELEGRAPH_RX_MODE) {
@@ -574,7 +571,6 @@ void main_ui(void) {
               g_volume = 0.1;
 
             /* Update the lcd display. */
-            ssp_clock_init();
             render_display();
           }
           break;
@@ -587,7 +583,6 @@ void main_ui(void) {
               g_volume = 1.0;
 
             /* Update the lcd display. */
-            ssp_clock_init();
             render_display();
           }
           break;
@@ -643,7 +638,6 @@ void telegraph_main(void) {
 	telegraph_init();
 
     /* Init r0cketlib in order to use the LCD display and the joystick. */
-    ssp_clock_init();
 	systickInit();
 
 	SETUPgout(LED4);

--- a/testapp/main.c
+++ b/testapp/main.c
@@ -26,7 +26,6 @@ void sys_tick_handler(void){
 
 int main(void) {
 	cpuClockInit(); /* CPU Clock is now 104 MHz */
-	ssp_clock_init();
 	systickInit();
 
 //	cpu_clock_set(204);


### PR DESCRIPTION
The SSP clock source and DIVC were modified in multiple places.

The result: The LCD was clocked with 50 MHz, way outside of its specs.
