### PR TITLE
lpcapi: add USB phy init to CDCenable(), like in MSCenable()

### DIFF
--- a/lpcapi/cdc/cdc_main.c
+++ b/lpcapi/cdc/cdc_main.c
@@ -56,6 +56,8 @@ void CDCenable(void) {
 
 	usb_clock_init();
 
+	usb_phy_enable();
+
 	/* Init USB API structure */
 	g_pUsbApi = (const USBD_API_T *) LPC_ROM_API->usbdApiBase;
 


### PR DESCRIPTION
The USB phy initialization wasn't called in CDCenable(). To make
that function behave like MSCenable() (and make testapp/cdc.c work),
add that initialization there.

Fixes #97
