### PR TITLE
Update README

### DIFF
--- a/al4rm/README
+++ b/al4rm/README
@@ -2,33 +2,59 @@ al4rm
 =====
 
 Data-Frame
++---------+--------------+------------------+
+| Header (fixed size)    | Payload (var)    |
++---------+--------------+------------------+
+| TypeId  | PayloadSize  | Data             |
++---------+--------------+------------------+
+| 8-Bit   | 8-bit        | n-byte (n=0-255) |
++---------+--------------+------------------+
 
-+---------+------------+------------------+
-| Channel | Frame-Size | Data             |
-+---------+------------+------------------+
-| 8-Bit   | 8-bit      | n-byte (n=0-255) |
-+---------+------------+------------------+
+| TypeId  | PSize | Description   | Data                      |
++---------+-------+----------------+--------------------------+
+| 0x00    | 1     | LEDMode        | Mode (see DMX)           |
+| 0x01    | 1     | DisplayMode    | Mode (see DMX)           |
+| 0x10    | 3     | Display Color  | RGB                      |
+| 0x11    | 3     | LED 0 Color    | RGB                      |
+| 0x12    | 3     | LED 1 Color    | RGB                      |
+| 0x13    | 3     | LED 2 Color    | RGB                      |
+| 0x14    | 3     | LED 3 Color    | RGB                      |
+| 0x15    | 3     | LED 4 Color    | RGB                      |
+| 0x16    | 3     | LED 5 Color    | RGB                      |
+| 0x17    | 3     | LED 6 Color    | RGB                      |
+| 0x18    | 3     | LED 7 Color    | RGB                      |
+| 0xF0    | 24    | All LED Colors | RGBRGBRGBRGBRGBRGBRGBRGB |
 
-| Channel | size | Description              | Data                     |
-+---------+------+--------------------------+--------------------------+
-| 0x10    | 0    | All LEDs off             |   -                      |
-| 0x11    | 3    | LED 1 Color              | RGB                      |
-| 0x12    | 3    | LED 2 Color              | RGB                      |
-| 0x13    | 3    | LED 3 Color              | RGB                      |
-| 0x14    | 3    | LED 4 Color              | RGB                      |
-| 0x15    | 3    | LED 5 Color              | RGB                      |
-| 0x16    | 3    | LED 6 Color              | RGB                      |
-| 0x17    | 3    | LED 7 Color              | RGB                      |
-| 0x18    | 3    | LED 8 Color              | RGB                      |
-| 0x19    |      | res                      |                          |
-| 0x1A    |      | res                      |                          |
-| 0x1B    |      | res                      |                          |
-| 0x1C    |      | res                      |                          |
-| 0x1D    |      | res                      |                          |
-| 0x1E    |      | res                      |                          |
-| 0x1F    | 3    | Display Color            | RGB                      |
-| 0x20    | 3    | All LEDs same Color      | RGB                      |
-| 0x21    | 24   | All LEDs diffrent Color  | RGBRGBRGBRGBRGBRGBRGBRGB |
-| 0x22    | 1    | Run LED animation Number | N                        |
-| 0x23    | 1    | Run Display animation No | N                        |
 
+DMX Channels
+
+| Channel | Description  | Value   | Settings             |
++---------+------------- +---------+----------------------+
+|     000 | LED Mode     |     000 | All LEDs off         |
+|         |              |     001 | All like LED0        |
+|         |              |     002 | Individual Colors    |
+|         |              | 003-009 | reserved             |
+|         |              | 010-255 | Animations           |
+|     001 | Display Mode |     000 | Display off          |
+|         |              |     001 | Same Color like LED0 |
+|         |              |     002 | Individual Color     |
+|         |              | 003-009 | reserved             |
+|         |              | 010-255 | Animations           |
+| 002-012 | reserved     |       - |                      |
+|     013 | Display R    | 000-255 | -                    |
+|     014 | Display G    | 000-255 | -                    |
+|     015 | Display B    | 000-255 | -                    |
+|     016 | LED 0 R      | 000-255 | -                    |
+|     017 | LED 0 G      | 000-255 | -                    |
+|     018 | LED 0 B      | 000-255 | -                    |
+|     019 | LED 1 R      | 000-255 | -                    |
+|     020 | LED 1 G      | 000-255 | -                    |
+|     021 | LED 1 B      | 000-255 | -                    |
+| cont'd  | -            |       - | -                    |
+|     037 | LED 7 R      | 000-255 | -                    |
+|     038 | LED 7 G      | 000-255 | -                    |
+|     039 | LED 7 B      | 000-255 | -                    |
+| cont'd  | -            |       - | -                    |
+|     253 | LED 80 R     | 000-255 | -                    |
+|     254 | LED 80 G     | 000-255 | -                    |
+|     255 | LED 80 B     | 000-255 | -                    |

--- a/al4rm/README
+++ b/al4rm/README
@@ -1,5 +1,4 @@
 # al4rm
-=====
 
 ## Data-Frame
 +---------+-------------+------------------+
@@ -12,57 +11,43 @@
 
 ### LED Subframe
 Type 0x10-0x1F (0x1 == (TypeId >> 4))
-+----------+--------------+-------------------------+
-| LEDMode  | DisplayMode  | LEDData                 |
-+----------+--------------+-------------------------+
-| 1 byte   | 1 byte       | n-byte (n=0-253)        |
-+----------+--------------+-------------------------+
-| see DMX Channels        |                         |
-+-------------------------+-------------------------+
+| TypeId  | size | Description              | Data                     |
++---------+------+--------------------------+--------------------------+
+| 0x10    | 0    | All LEDs and Display off | -                        |
+| 0x11    | 3    | All LEDs same Color      | RGB                      |
+| 0x12    | 3    | Display Color            | RGB                      |
+| 0x13    | 1    | Run LED animation Number | N                        |
+| 0x14    | 1    | Run Display animation No | N                        |
+| 0x15    | 4    | LED x Color              | x RGB                    |
+| 0x1D    | 24   | All LEDs different Color | RGBRGBRGBRGBRGBRGBRGBRGB |
+| 0x1E    | -    | -                        | -                        |
+| 0x1F    | -    | -                        | -                        |
 
-| TypeId  | PSize | Description    | Data                           |
-+---------+-------+----------------+--------------------------------+
-| 0x10    | 5     | Display Color  | LM DM RGB                      |
-| 0x11    | 5     | LED 0 Color    | LM DM RGB                      |
-| 0x12    | 5     | LED 1 Color    | LM DM RGB                      |
-| 0x13    | 5     | LED 2 Color    | LM DM RGB                      |
-| 0x14    | 5     | LED 3 Color    | LM DM RGB                      |
-| 0x15    | 5     | LED 4 Color    | LM DM RGB                      |
-| 0x16    | 5     | LED 5 Color    | LM DM RGB                      |
-| 0x17    | 5     | LED 6 Color    | LM DM RGB                      |
-| 0x18    | 5     | LED 7 Color    | LM DM RGB                      |
-| 0x1F    | 26    | All LED Colors | LM DM RGBRGBRGBRGBRGBRGBRGBRGB |
-LM = LEDMode, DM = DisplayMode
 
 ## DMX Channels
 
 | Channel | Description  | Value   | Settings             |
 +---------+------------- +---------+----------------------+
-|     000 | LED Mode     |     000 | All LEDs off         |
+|     001 | LED Mode     |     000 | All LEDs off         |
 |         |              |     001 | All like LED0        |
 |         |              |     002 | Individual Colors    |
 |         |              | 003-009 | reserved             |
 |         |              | 010-255 | Animations           |
-|     001 | Display Mode |     000 | Display off          |
+|     002 | Display Mode |     000 | Display off          |
 |         |              |     001 | Same Color like LED0 |
 |         |              |     002 | Individual Color     |
 |         |              | 003-009 | reserved             |
 |         |              | 010-255 | Animations           |
-| 002-012 | reserved     |       - |                      |
-|     013 | Display R    | 000-255 | -                    |
-|     014 | Display G    | 000-255 | -                    |
-|     015 | Display B    | 000-255 | -                    |
-|     016 | LED 0 R      | 000-255 | -                    |
-|     017 | LED 0 G      | 000-255 | -                    |
-|     018 | LED 0 B      | 000-255 | -                    |
-|     019 | LED 1 R      | 000-255 | -                    |
-|     020 | LED 1 G      | 000-255 | -                    |
-|     021 | LED 1 B      | 000-255 | -                    |
+|     003 | LED 0 R      | 000-255 | -                    |
+|     004 | LED 0 G      | 000-255 | -                    |
+|     005 | LED 0 B      | 000-255 | -                    |
+|     006 | LED 1 R      | 000-255 | -                    |
+|     007 | LED 1 G      | 000-255 | -                    |
+|     008 | LED 1 B      | 000-255 | -                    |
 | cont'd  | -            |       - | -                    |
-|     037 | LED 7 R      | 000-255 | -                    |
-|     038 | LED 7 G      | 000-255 | -                    |
-|     039 | LED 7 B      | 000-255 | -                    |
-| cont'd  | -            |       - | -                    |
-|     253 | LED 80 R     | 000-255 | -                    |
-|     254 | LED 80 G     | 000-255 | -                    |
-|     255 | LED 80 B     | 000-255 | -                    |
+|     024 | LED 7 R      | 000-255 | -                    |
+|     025 | LED 7 G      | 000-255 | -                    |
+|     026 | LED 7 B      | 000-255 | -                    |
+|     027 | Display R    | 000-255 | -                    |
+|     028 | Display G    | 000-255 | -                    |
+|     029 | Display B    | 000-255 | -                    |

--- a/al4rm/README
+++ b/al4rm/README
@@ -1,32 +1,40 @@
-al4rm
+# al4rm
 =====
 
-Data-Frame
-+---------+--------------+------------------+
-| Header (fixed size)    | Payload (var)    |
-+---------+--------------+------------------+
-| TypeId  | PayloadSize  | Data             |
-+---------+--------------+------------------+
-| 8-Bit   | 8-bit        | n-byte (n=0-255) |
-+---------+--------------+------------------+
+## Data-Frame
++---------+-------------+------------------+
+| Header (fixed size)   | Payload (var)    |
++---------+--------------------------------+
+| TypeId  | PayloadSize | Data             |
++---------+--------------------------------+
+| 1 byte  | 1 byte      | n-byte (n=0-255) |
++---------+--------------------------------+
 
-| TypeId  | PSize | Description   | Data                      |
-+---------+-------+----------------+--------------------------+
-| 0x00    | 1     | LEDMode        | Mode (see DMX)           |
-| 0x01    | 1     | DisplayMode    | Mode (see DMX)           |
-| 0x10    | 3     | Display Color  | RGB                      |
-| 0x11    | 3     | LED 0 Color    | RGB                      |
-| 0x12    | 3     | LED 1 Color    | RGB                      |
-| 0x13    | 3     | LED 2 Color    | RGB                      |
-| 0x14    | 3     | LED 3 Color    | RGB                      |
-| 0x15    | 3     | LED 4 Color    | RGB                      |
-| 0x16    | 3     | LED 5 Color    | RGB                      |
-| 0x17    | 3     | LED 6 Color    | RGB                      |
-| 0x18    | 3     | LED 7 Color    | RGB                      |
-| 0xF0    | 24    | All LED Colors | RGBRGBRGBRGBRGBRGBRGBRGB |
+### LED Subframe
+Type 0x10-0x1F (0x1 == (TypeId >> 4))
++----------+--------------+-------------------------+
+| LEDMode  | DisplayMode  | LEDData                 |
++----------+--------------+-------------------------+
+| 1 byte   | 1 byte       | n-byte (n=0-253)        |
++----------+--------------+-------------------------+
+| see DMX Channels        |                         |
++-------------------------+-------------------------+
 
+| TypeId  | PSize | Description    | Data                           |
++---------+-------+----------------+--------------------------------+
+| 0x10    | 5     | Display Color  | LM DM RGB                      |
+| 0x11    | 5     | LED 0 Color    | LM DM RGB                      |
+| 0x12    | 5     | LED 1 Color    | LM DM RGB                      |
+| 0x13    | 5     | LED 2 Color    | LM DM RGB                      |
+| 0x14    | 5     | LED 3 Color    | LM DM RGB                      |
+| 0x15    | 5     | LED 4 Color    | LM DM RGB                      |
+| 0x16    | 5     | LED 5 Color    | LM DM RGB                      |
+| 0x17    | 5     | LED 6 Color    | LM DM RGB                      |
+| 0x18    | 5     | LED 7 Color    | LM DM RGB                      |
+| 0x1F    | 26    | All LED Colors | LM DM RGBRGBRGBRGBRGBRGBRGBRGB |
+LM = LEDMode, DM = DisplayMode
 
-DMX Channels
+## DMX Channels
 
 | Channel | Description  | Value   | Settings             |
 +---------+------------- +---------+----------------------+


### PR DESCRIPTION
Added DMX Channel description and did an adoption to the al4rm data frame to minimize translation effort from DMX.
Aligned the DMX LED Channel number so virtually 80 LEDs could fit, don't know what's coming up in the future...
To be checked:
- Dedicated DMX Channel for LED and Display animations? (I feel fine with the animations in the mode channel)
- Is it reasonable to send all LED colours in a single al4rm data packet (0xF0)? (Shorter packets (=sending colours separately) may be more reliable, but cause more overhead) - I think we'll have to test.
