### PR TITLE
campapp: RGB LED amplifying

### DIFF
--- a/campapp/rgb_leds.c
+++ b/campapp/rgb_leds.c
@@ -7,15 +7,16 @@
 #include <r0ketlib/keyin.h>
 #include <string.h>
 #include <math.h>
+#include <stdint.h>
 #include <campapp/rad1oconfig.h>
 
 #define MAX_LED_FRAMES 50
 #define BUF_SIZE 3*8*MAX_LED_FRAMES+2
 
-unsigned char leds[BUF_SIZE];
-unsigned int frames = 0;
-unsigned int ctr = 0;
-unsigned int framectr = 0;
+uint8_t leds[BUF_SIZE];
+uint8_t frames = 0;
+uint16_t ctr = 0;
+uint8_t framectr = 0;
 
 void readRgbLedFile(void) {
 	int size = getFileSize(GLOBAL(ledfile));
@@ -41,10 +42,10 @@ void tick_rgbLeds(void) {
 	if(GLOBAL(rgbleds)) {
 		if(frames > 0) {
 			if(ctr == 0) {
-				unsigned char amplified[3*8];
+				uint8_t amplified[3*8];
 
 				// determine amplifier level based on the config
-				signed char amplvl = GLOBAL(rgbleds_amp) - 8;
+				int8_t amplvl = GLOBAL(rgbleds_amp) - 8;
 				if (amplvl > 0) {
 					amplvl = round(sqrt(pow(2,amplvl+1)));
 				} else if (amplvl < 0) {
@@ -54,9 +55,9 @@ void tick_rgbLeds(void) {
 				}
 
 				// iterate through every value in the frame (3 channels * 8 LEDs)
-				for (int i=0; i<3*8; i++) {
+				for (int8_t i=0; i<3*8; i++) {
 					// copy original value
-					unsigned char origval = leds[(framectr*3*8+2)+i];
+					uint8_t origval = leds[(framectr*3*8+2)+i];
 					// set the amplified value
 					if (amplvl >= 0) {
 						amplified[i] = origval * amplvl;

--- a/r0ketlib/config.c
+++ b/r0ketlib/config.c
@@ -35,6 +35,7 @@ struct CDESC the_config[]= {
     {"nickbg",           255,   0, 255, 1, CFG_TYPE_DEVEL},
     {"vdd_fix",          0,     0, 1,   0, 0},
     {"rgbleds",          0,     0, 1,   0, 0},
+    {"rgbleds_amp",      8,     0, 16,  0, 0},
     { NULL,              0,     0, 0  , 0, 0},
 };
 

--- a/r0ketlib/config.h
+++ b/r0ketlib/config.h
@@ -49,6 +49,7 @@ extern char ledfile[];
 #define GLOBALnickbg       (the_config[13].value)
 #define GLOBALvdd_fix      (the_config[14].value)
 #define GLOBALrgbleds      (the_config[15].value)
+#define GLOBALrgbleds_amp   (the_config[16].value)
 
 #define GLOBAL(x) GLOBAL ## x
 


### PR DESCRIPTION
Brightness of RGB LED animations varies a lot, and sometimes
desired brightness depends on the environment and situation.
Aside of editing the animations directly, there was no way to
adjust the brightness of the LEDs.

This commit introduces a new config entry, "rgbleds_amp", which
allows to adjust the brightness of RGB LEDs in campapp animations.

The default value of 8 is a neutral setting.

Keep in mind that with static animations amp setting does not
apply immediately (either the frame delay must pass or the new
animation has to be loaded).
