### PR TITLE
Fix Makefile.hackrf.

### DIFF
--- a/Makefile.hackrf
+++ b/Makefile.hackrf
@@ -14,7 +14,7 @@ hackrf/firmware/libopencm3/README:
 
 hackrf/firmware/libopencm3/lib/libopencm3_lpc43xx.a: $(FORCE)
 	git -C hackrf submodule update
-	$(MAKE) -C firmware/libopencm3
+	$(MAKE) -C hackrf/firmware/libopencm3
 
 lib: hackrf/firmware/libopencm3/README hackrf/firmware/libopencm3/lib/libopencm3_lpc43xx.a
 


### PR DESCRIPTION
Fix for a typo.

It does not build on my arch container due to an upstream issue of hackrf_usb.dfu not being built.