### PR TITLE
fix default.nix for nixos>=19.03

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ with import <nixpkgs> {}; {
   env = stdenv.mkDerivation {
     name = "rad1o-f1rmware-env";
     buildInputs = [
-      stdenvCross
+      gcc-arm-embedded
       python2
       python2Packages.pyyaml
       gcc-arm-embedded


### PR DESCRIPTION
The cross compilation tooling for nixos got changed in the last release and the package name of the compiler was changed.
With this fix I was able to start the nix-shell and build most recent master.