### PR TITLE
add cacert to default.nix environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ with import <nixpkgs> {}; {
       dfu-util
       cmake
       libusb
+      cacert
     ];
-    SSL_CERT_FILE="/etc/ssl/certs/ca-bundle.crt";
   };
 }


### PR DESCRIPTION
Fixes validation errors while cloning from GitHub.

```
[nix-shell:/run/user/1000/.uPUd/f1rmware]$ make
git submodule init
Submodule 'hackrf' (https://github.com/rad1o/hackrf.git) registered for path 'hackrf'
Submodule 'libopencm3' (https://github.com/rad1o/libopencm3.git) registered for path 'libopencm3'
git submodule update
Cloning into '/run/user/1000/.uPUd/f1rmware/hackrf'...
fatal: unable to access 'https://github.com/rad1o/hackrf.git/': SSL certificate problem: unable to get local issuer certificate
fatal: clone of 'https://github.com/rad1o/hackrf.git' into submodule path '/run/user/1000/.uPUd/f1rmware/hackrf' failed
Failed to clone 'hackrf'. Retry scheduled
Cloning into '/run/user/1000/.uPUd/f1rmware/libopencm3'...
fatal: unable to access 'https://github.com/rad1o/libopencm3.git/': SSL certificate problem: unable to get local issuer certificate
fatal: clone of 'https://github.com/rad1o/libopencm3.git' into submodule path '/run/user/1000/.uPUd/f1rmware/libopencm3' failed
Failed to clone 'libopencm3'. Retry scheduled
Cloning into '/run/user/1000/.uPUd/f1rmware/hackrf'...
fatal: unable to access 'https://github.com/rad1o/hackrf.git/': SSL certificate problem: unable to get local issuer certificate
fatal: clone of 'https://github.com/rad1o/hackrf.git' into submodule path '/run/user/1000/.uPUd/f1rmware/hackrf' failed
Failed to clone 'hackrf' a second time, aborting
make: *** [Makefile:23: libopencm3/README] Error 1
```