### PR TITLE
Fixed linking in ccccmaze and hackrfapp with GCC 9+

### DIFF
--- a/ccccmaze/Makefile
+++ b/ccccmaze/Makefile
@@ -50,6 +50,8 @@ CFLAGS+=-I../hackrf-old/firmware/common
 
 LIBS += -lm
 
+LDFLAGS += --specs=rdimon.specs
+
 LDSCRIPT=../ld/app.ld
 RPATH=..
 include ../Makefile.inc

--- a/hackrfapp/Makefile
+++ b/hackrfapp/Makefile
@@ -83,6 +83,8 @@ CFLAGS+=-I../hackrf-old/firmware/common
 
 LIBS += -lm
 
+LDFLAGS += --specs=rdimon.specs
+
 LDSCRIPT=../ld/app.ld
 RPATH=..
 include ../Makefile.inc


### PR DESCRIPTION
Those apps generated linker errors like:

```
/opt/gcc-arm-none-eabi-10.3-2021.10/arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(lib_a-abort.o):
in function `abort':
abort.c:(.text.abort+0xa): undefined reference to `_exit'
```

This works with [ARM GCC Toolchains](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads) starting at _8-2019-q3-update_. I have not tested earlier toolchains.