### PR TITLE
r0ketlib: Fix handling of extensionless files in selectFileRepeat

### DIFF
--- a/r0ketlib/select.c
+++ b/r0ketlib/select.c
@@ -84,7 +84,7 @@ int selectFileRepeat(char *filename, const char *extension){
                 lcdPrint("*");
             lcdSetCrsrX(14);
             int dot=-1;
-            for(int j=0;files[j];j++)
+            for(int j=0;files[i][j];j++)
                 if(files[i][j]=='.'){
                     files[i][j]=0;
                     dot=j;


### PR DESCRIPTION
Caught by recent GCC:

```
../r0ketlib/select.c: In function 'selectFileRepeat': ../r0ketlib/select.c:87:25: error: the comparison will always evaluate as 'true' for the address of 'files' will never be NULL [-Werror=address]
   87 |             for(int j=0;files[j];j++)
      |                         ^~~~~
../r0ketlib/select.c:71:14: note: 'files' declared here
   71 |         char files[PERPAGE][FLEN];
      |              ^~~~~
```